### PR TITLE
build: Docker BuildKit migration (base-python, remove build.yaml)

### DIFF
--- a/modbus-proxy/CHANGELOG.md
+++ b/modbus-proxy/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.2.7] - 2026-05-11
+
+### Changed
+- **Build (Docker BuildKit)** - Migrated from `build.yaml` to a pinned multi-arch base image `ghcr.io/home-assistant/base-python:3.13-alpine3.23` in the `Dockerfile` (default `BUILD_FROM`; Supervisor may still override at build time). Aligns with [Migrating app builds to Docker BuildKit](https://developers.home-assistant.io/blog/2026/04/02/builder-migration).
+
+### Breaking
+- **Supported architectures** - `armhf` and `armv7` are no longer listed in `config.yaml`. Official Home Assistant base images for this path are multi-arch for **amd64** and **arm64** only. Use a 64-bit OS (e.g. aarch64) on Raspberry Pi-class hardware.
+
 ## [2.2.6] - 2025-10-26
 
 ### Fixed

--- a/modbus-proxy/Dockerfile
+++ b/modbus-proxy/Dockerfile
@@ -1,5 +1,13 @@
-ARG BUILD_FROM
+# Multi-arch Python base for Home Assistant apps (Docker BuildKit).
+# Default can be overridden by Supervisor/build with --build-arg BUILD_FROM=...
+ARG BUILD_FROM=ghcr.io/home-assistant/base-python:3.13-alpine3.23
 FROM $BUILD_FROM
+
+LABEL \
+    org.opencontainers.image.title="Modbus Proxy" \
+    org.opencontainers.image.description="Multi-device Modbus TCP and RTU proxy add-on" \
+    org.opencontainers.image.source="https://github.com/TCzerny/ha-modbusproxy" \
+    org.opencontainers.image.licenses="Apache-2.0"
 
 WORKDIR /srv
 

--- a/modbus-proxy/build.yaml
+++ b/modbus-proxy/build.yaml
@@ -1,4 +1,0 @@
-build_from:
-  amd64:   homeassistant/amd64-base-python
-  aarch64: homeassistant/aarch64-base-python
-  armv7:   homeassistant/armv7-base-python

--- a/modbus-proxy/config.yaml
+++ b/modbus-proxy/config.yaml
@@ -1,12 +1,10 @@
 name: "Modbus Proxy"
-version: "2.2.6"
+version: "2.2.7"
 slug: "modbus_proxy"
 description: "A powerful multi-device Modbus TCP and RTU proxy"
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
 url: "https://github.com/TCzerny/ha-modbusproxy"
 startup: services
 init: false


### PR DESCRIPTION
## Summary
Migrates the add-on image build to the Home Assistant [BuildKit guidance](https://developers.home-assistant.io/blog/2026/04/02/builder-migration): single multi-arch base in the Dockerfile, `build.yaml` removed.

## Changes
- Default `BUILD_FROM`: `ghcr.io/home-assistant/base-python:3.13-alpine3.23` (still overridable at build time)
- OCI labels in Dockerfile
- `config.yaml`: version **2.2.7**, architectures **aarch64** / **amd64** only (32-bit ARM dropped — see CHANGELOG)
- CHANGELOG entry with breaking note

## Testing
- Local `docker buildx build` for `linux/amd64` succeeded
- Recommend HA/Supervisor smoke test on real hardware before wider release


Made with [Cursor](https://cursor.com)